### PR TITLE
Redo Exception message : Patherror

### DIFF
--- a/asabiris/exceptions.py
+++ b/asabiris/exceptions.py
@@ -4,16 +4,17 @@ class SMTPDeliverError(Exception):
 
 class PathError(Exception):
 	"""
-
 	Equivalent to HTTP 404 Not-Found.
 	"""
 
-	def __init__(self, message=None, *args, path=None):
-		self.Path = path
+	def __init__(self, message=None, *args, use_case=None, invalid_path=None):
+		self.use_case = use_case
+		self.invalid_path = invalid_path
+
 		if message is not None:
 			super().__init__(message, *args)
-		elif path is not None:
-			message = "Invalid path {!r}.".format(path)
+		elif invalid_path is not None:
+			message = "Invalid path '{}'. Expected path to start with '/Templates/{}/'.".format(invalid_path, use_case)
 			super().__init__(message, *args)
 		else:
 			super().__init__(message, *args)

--- a/asabiris/exceptions.py
+++ b/asabiris/exceptions.py
@@ -8,8 +8,8 @@ class PathError(Exception):
 	"""
 
 	def __init__(self, message=None, *args, use_case=None, invalid_path=None):
-		self.use_case = use_case
-		self.invalid_path = invalid_path
+		self.UseCase = use_case
+		self.InvalidPath = invalid_path
 
 		if message is not None:
 			super().__init__(message, *args)

--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -71,7 +71,7 @@ class SendEmailOrchestrator(object):
 					params = a.get('params', {})
 					# templates must be stores in /Templates/Email
 					if not template.startswith("/Templates/Email/"):
-						raise PathError(path=template)
+						raise PathError(use_case='Email', invalid_path=template)
 
 					# get file-name of the attachment
 					file_name = self.get_file_name(a)
@@ -123,7 +123,7 @@ class SendEmailOrchestrator(object):
 		"""
 		# templates must be stores in /Templates/Emails
 		if not template.startswith("/Templates/Email/"):
-			raise PathError(path=template)
+			raise PathError(use_case='Email', invalid_path=template)
 
 		try:
 			jinja_output = await self.JinjaService.format(template, params)

--- a/asabiris/orchestration/sendmsteams.py
+++ b/asabiris/orchestration/sendmsteams.py
@@ -48,7 +48,7 @@ class SendMSTeamsOrchestrator(object):
 
 		body = msg['body']
 		if not body['template'].startswith("/Templates/MSTeams/"):
-			raise PathError(path=body['template'])
+			raise PathError(use_case='MSTeams', invalid_path=body['template'])
 
 		body["params"] = body.get("params", {})
 		output = await self.JinjaService.format(body["template"], body["params"])

--- a/asabiris/orchestration/sendslack.py
+++ b/asabiris/orchestration/sendslack.py
@@ -44,7 +44,7 @@ class SendSlackOrchestrator(object):
 
 		# templates must be stores in /Templates/Slack
 		if not body['template'].startswith("/Templates/Slack/"):
-			raise PathError(path=body['template'])
+			raise PathError(use_case='Slack', invalid_path=body['template'])
 
 		atts = []
 


### PR DESCRIPTION
New rephrased message from PathError exception.

```
{
    "result": "NOT-FOUND",
    "message": "Invalid path '/Templates/Slacks/alert.md'. Expected path to start with '/Templates/Slack/'.",
    "uuid": "f254ad38-7ce7-4d23-9e24-5ff8ed08d97f"
}
```

```
{
    "result": "NOT-FOUND",
    "message": "Invalid path '/Templates/Emails/hello.html'. Expected path to start with '/Templates/Email/'.",
    "uuid": "497171a2-8e14-4460-bbc0-a3a262f6209d"
}
```