### PR TITLE
Create nested dict from dots in keys

### DIFF
--- a/asabiris/formatter/jinja/service.py
+++ b/asabiris/formatter/jinja/service.py
@@ -25,4 +25,33 @@ class JinjaFormatterService(asab.Service, FormatterABC):
 			raise KeyError("Template '{}' not found".format(template_path))
 
 		template = jinja2.Template(template_io.read().decode('utf-8'))
+
+		# This creates nested dictionary from keys with dot notation
+		template_params = create_nested_dict_from_dots_in_keys(template_params)
 		return template.render(**template_params)
+
+
+def create_nested_dict_from_dots_in_keys(data):
+	"""
+	This function creates a nested dictionary from a dictionary with keys containing dots.
+
+	:param data: The input dictionary that may contain keys with dots in them, indicating nested levels
+	of dictionaries
+	:return: a nested dictionary where keys containing dots (".") have been split into sub-dictionaries.
+	"""
+	nested_dict = {}
+	for key, value in data.items():
+		if isinstance(value, dict):
+			value = create_nested_dict_from_dots_in_keys(value)
+
+		if '.' in key:
+			parts = key.split('.')
+			current_dict = nested_dict
+			for part in parts[:-1]:
+				current_dict.setdefault(part, {})
+				current_dict = current_dict[part]
+
+			current_dict[parts[-1]] = value
+		else:
+			nested_dict[key] = value
+	return nested_dict

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -201,8 +201,8 @@ class WebHandler(object):
 		return asab.web.rest.json_response(request, {"result": "OK"})
 
 
-	# TODO: JSON schema
-	async def render(self, request):
+	@asab.web.rest.json_schema_handler({"type": "object"})
+	async def render(self, request, *, json_data):
 		"""
 		This endpoint renders request body into template based on the format specified.
 		Example:
@@ -223,6 +223,8 @@ class WebHandler(object):
 			"state":"MH"
 		}
 		```
+		---
+		parameters: [{"name": "format", "in": "query", "description": "Format of the document"}, {"name": "template", "in": "query", "description": "Reference to the template"}]
 		"""
 		fmt = request.query.get("format", "html")
 		template = request.query.get("template", None)


### PR DESCRIPTION
I didn't test it in the iris, yet but I did this:

```python
yaml_data = [
	{"alert": {"event.other.id": "1234"}},
	{"alert.event.id": 1,
		"alert2": {
			"event": {
				"id": 2}}},
	{"alert.message": "Windows AD logs activity on 4728",
	 "alert.event.id": "!ITEM EVENT lmio_id",
	 "alert.event.name": "windows-4728-log-notification"},
]


def create_nested_dict_from_dots_in_keys(data):
	nested_dict = {}
	for key, value in data.items():
		if isinstance(value, dict):
			value = create_nested_dict_from_dots_in_keys(value)

		if '.' in key:
			parts = key.split('.')
			current_dict = nested_dict
			for part in parts[:-1]:
				current_dict.setdefault(part, {})
				current_dict = current_dict[part]

			current_dict[parts[-1]] = value
		else:
			nested_dict[key] = value
	return nested_dict


for i in yaml_data:
	print(i)
	print(">>>", create_nested_dict_from_dots_in_keys(i))
```

```
{'alert': {'event.other.id': '1234'}}
>>> {'alert': {'event': {'other': {'id': '1234'}}}}
{'alert.event.id': 1, 'alert2': {'event': {'id': 2}}}
>>> {'alert': {'event': {'id': 1}}, 'alert2': {'event': {'id': 2}}}
{'alert.message': 'Windows AD logs activity on 4728', 'alert.event.id': '!ITEM EVENT lmio_id', 'alert.event.name': 'windows-4728-log-notification'}
>>> {'alert': {'message': 'Windows AD logs activity on 4728', 'event': {'id': '!ITEM EVENT lmio_id', 'name': 'windows-4728-log-notification'}}}
```