### PR TITLE
Email : Subject condition change

### DIFF
--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -53,7 +53,7 @@ class SendEmailOrchestrator(object):
 		# Render a body
 		body_html, email_subject_body = await self.render(body_template, body_params)
 
-		if email_subject is None:
+		if email_subject is None or email_subject == '':
 			email_subject = email_subject_body
 
 		atts = []


### PR DESCRIPTION
It appears that when someone does not wish to pass the subject from the user interface, they sent me an empty value. Consequently, I had to make the necessary adjustments accordingly.