### PR TITLE
Add default kafka config

### DIFF
--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -35,7 +35,7 @@ asab.Config.add_defaults({
 		"body_max_size": 31457280  # maximum size of the request body that the web server can handle.
 	},
 	"kafka": {
-		"topic": "asab-notifications",
+		"topic": "notifications",
 		"group_id": "asab-iris",
 	}
 })

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -33,6 +33,10 @@ asab.Config.add_defaults({
 	"web": {
 		"listen": 8896,  # Well-known port of asab iris
 		"body_max_size": 31457280  # maximum size of the request body that the web server can handle.
+	},
+	"kafka": {
+		"topic": "asab-notifications",
+		"group_id": "asab-iris",
 	}
 })
 


### PR DESCRIPTION
Config for maestro. Default topic is `asab-notifications`. It cannot be `lmio-notifications` within asab service.