### PR TITLE
Add `GET /features` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # CHANGELOG
 
-## Release Candidate
+## v25.10
+
+### Features
+- Add `GET /features` endpoint (#90, v25.10-alpha2)
+- Add new jinja2 filter quote_plus (#89, v25.10-alpha)
+
+### Fixes
+- Remove exits from Kafka handler (#86, v25.08-alpha)
+
+---
+
+
+## v25.07
+
+### Features
+- Tenant configuration (#84)
+- Enhancement: Optional services (#83)
+
+### Fixes
+- Use correct incoming webhook url (#88)
+- Use zookeeper container (#87)
+- Email supports TXT templates (#82)
+
+### Refactoring
+- Kafka handler refactoring (#81)
+
+---
+
+
+## v24.42
 
 ### Features
 
@@ -16,10 +45,13 @@
 
 - Feature: Send SMS
 
+#### 28. 06. 2024 
+
+- Feature: Send SMS
+
 
 ### Refactoring
 
-- 
 #### 26. 05. 2023
 
 - Refactoring :Slack use case
@@ -34,8 +66,6 @@
 
 
 ### Enhancements
-
-- 
 
 #### 09. 04. 2023 
 
@@ -109,23 +139,8 @@
 
 - Email supports TXT templates
 
-#### 21.02.2025
-
-- Make Kafka handler optional
-
-#### 21.02.2025
-
-- Exit strategy is obsolete
-
-
-#### 03.03.2025
-
-- jinja2 new filter quote_plus
-
 
 ### Bugfix
-
-- 
 
 #### 13. 06. 2023
 

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -149,3 +149,16 @@ class ASABIRISApplication(asab.Application):
 		# Apache Kafka API is conditional
 		if "kafka" in asab.Config.sections():
 			self.KafkaHandler = KafkaHandler(self)
+
+
+	def enabled_orchestrators(self):
+		if self.SendEmailOrchestrator is not None:
+			yield "email"
+		if self.SendMSTeamsOrchestrator is not None:
+			yield "slack"
+		if self.SendMSTeamsOrchestrator is not None:
+			yield "msteams"
+		if self.SendMSTeamsOrchestrator is not None:
+			yield "sms"
+		if self.RenderReportOrchestrator is not None:
+			yield "render-report"

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -96,7 +96,13 @@ class ASABIRISApplication(asab.Application):
 			self.TenantConfigExtractionService = None
 
 		# output services
-		self.EmailOutputService = EmailOutputService(self)
+
+		if asab.Config.get("smtp", "host") != "":
+			self.EmailOutputService = EmailOutputService(self)
+			self.SendEmailOrchestrator = SendEmailOrchestrator(self)
+		else:
+			self.EmailOutputService = None
+			self.SendEmailOrchestrator = None
 
 		if 'slack' in asab.Config.sections():
 			# Initialize the SlackOutputService
@@ -136,7 +142,6 @@ class ASABIRISApplication(asab.Application):
 
 
 		# Orchestrators
-		self.SendEmailOrchestrator = SendEmailOrchestrator(self)
 		self.RenderReportOrchestrator = RenderReportOrchestrator(self)
 
 		self.WebHandler = WebHandler(self)

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -36,6 +36,9 @@ class WebHandler(object):
 
 
 	async def get_features(self, request):
+		"""
+		Return the application's features (enabled orchestrators).
+		"""
 		response = {
 			"orchestrators": list(self.App.enabled_orchestrators()),
 		}

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -105,6 +105,15 @@ class WebHandler(object):
 		---
 		tags: ['Send mail']
 		"""
+		if self.App.SendEmailOrchestrator is None:
+			L.info("Email orchestrator is not enabled.")
+			return aiohttp.web.json_response(
+				{
+					"result": "FAILED",
+					"error": "Email service is not configured."
+				},
+				status=400
+			)
 
 		try:
 			await self.App.SendEmailOrchestrator.send_email(

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -26,12 +26,20 @@ class WebHandler(object):
 		self.App = app
 
 		web_app = app.WebContainer.WebApp
+		web_app.router.add_get(r"/features", self.get_features)
 		web_app.router.add_put(r"/send_email", self.send_email)
 		web_app.router.add_put(r"/send_mail", self.send_email)  # This one is for backward compatibility
 		web_app.router.add_put(r"/render", self.render)
 		web_app.router.add_put(r"/send_sms", self.send_sms)
 		web_app.router.add_put(r"/send_slack", self.send_slack)
 		web_app.router.add_put(r"/send_msteams", self.send_msteams)
+
+
+	async def get_features(self, request):
+		response = {
+			"orchestrators": list(self.App.enabled_orchestrators()),
+		}
+		return asab.web.rest.json_response(request, response)
 
 
 	@asab.web.rest.json_schema_handler(email_schema)

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -37,7 +37,7 @@ class EmailOutputService(asab.Service, OutputABC):
 
 		self.Host = asab.Config.get(config_section_name, "host")
 		if self.Host == "":
-			L.warning("SMTP server is not configured, the `host` entry is empty")
+			raise ValueError("SMTP server is not configured, the `host` entry is empty")
 		self.Port = asab.Config.get(config_section_name, "port")
 
 		self.SSL = asab.Config.getboolean(config_section_name, "ssl")


### PR DESCRIPTION
# Summary

- Introduce `GET /features` endpoint. For now, it returns list of enabled orchestrators, e.g.:
```json
{
  "orchestrators": ["email", "slack", "render-report"]
}
```

- Do not initialize SMTP service when there is no SMTP host configured.