### PR TITLE
New method send email raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,17 @@
 
 ## v25.xx
 
+### Enhancements
 - Cert Bundle support to SMTP service. (#112 v25.36-alpha)
 - SMS Normalization & Prefix Handling. (#110 v25.36-alpha2)
+- Manage Library not ready exception.(#109, v25.34-alpha2)
+- SMS phone is tenant specific. (#106, v25.32-alpha2)
+- Update SMS Schema. (#107, v25.33-alpha2)
+
+### Fixes
+- Fix error while sending error notification in email. (#110 v25.38-alpha)
+- Introduce send email raw. (#111 v25.38-alpha)
+
 ---
 
 ## v25.28.02

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -1,4 +1,5 @@
 import logging
+import configparser
 import asab.api
 import asab
 import asab.web.rest
@@ -97,11 +98,15 @@ class ASABIRISApplication(asab.Application):
 			self.TenantConfigExtractionService = None
 
 		# output services
-
-		# output services
 		# SMTP
-		if asab.Config.get("smtp", "host"):
-			self.EmailOutputService = EmailOutputService(self)
+		try:
+			host = asab.Config.get("smtp", "host")
+		except (configparser.NoSectionError, configparser.NoOptionError):
+			host = ""
+
+		if host:
+			# register under SmtpService so orchestrator can find it
+			self.EmailOutputService = EmailOutputService(self, service_name="SmtpService")
 		else:
 			self.EmailOutputService = None
 

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -160,15 +160,14 @@ class ASABIRISApplication(asab.Application):
 		if "kafka" in asab.Config.sections():
 			self.KafkaHandler = KafkaHandler(self)
 
-
 	def enabled_orchestrators(self):
 		if self.SendEmailOrchestrator is not None:
 			yield "email"
-		if self.SendMSTeamsOrchestrator is not None:
+		if self.SendSlackOrchestrator is not None:
 			yield "slack"
 		if self.SendMSTeamsOrchestrator is not None:
 			yield "msteams"
-		if self.SendMSTeamsOrchestrator is not None:
+		if self.SendSMSOrchestrator is not None:
 			yield "sms"
 		if self.RenderReportOrchestrator is not None:
 			yield "render-report"

--- a/asabiris/handlers/kafkahandler.py
+++ b/asabiris/handlers/kafkahandler.py
@@ -243,11 +243,12 @@ class KafkaHandler(asab.Service):
 			if service_type == 'email' and msg:
 				try:
 					L.log(asab.LOG_NOTICE, "Sending error notification to email.")
-					await self.App.EmailOutputService.send(
+					await self.App.SendEmailOrchestrator.send_email_raw(
 						email_from=msg.get('from', None),
 						email_to=msg['to'],
-						email_subject=error_subject,
-						body=error_message
+						email_subject=error_subject or "Error Notification",
+						body=error_message,
+						content_type="HTML"
 					)
 				except Exception:
 					L.exception("Error notification to email unsuccessful.")

--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -180,7 +180,7 @@ class SendEmailOrchestrator:
 	):
 		email_cc = email_cc or []
 		email_bcc = email_bcc or []
-		attachments = attachments or []
+		attachments = attachments or None
 
 		# Prefer SMTP
 		if self.SmtpService is not None:

--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -168,15 +168,15 @@ class SendEmailOrchestrator:
 		)
 
 	async def send_email_raw(
-			self,
-			email_from,
-			email_to,
-			email_subject,
-			body,
-			email_cc=None,
-			email_bcc=None,
-			attachments=None,
-			content_type="HTML"
+		self,
+		email_from,
+		email_to,
+		email_subject,
+		body,
+		email_cc=None,
+		email_bcc=None,
+		attachments=None,
+		content_type="HTML"
 	):
 		email_cc = email_cc or []
 		email_bcc = email_bcc or []

--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -82,7 +82,7 @@ class SendEmailOrchestrator:
 		if self.SmtpService is not None:
 			atts_gen = self.AttachmentRenderingService.render_attachment(attachments)
 			await self.SmtpService.send(
-				email_from,
+				email_from=email_from,
 				email_to=email_to,
 				email_cc=email_cc,
 				email_bcc=email_bcc,
@@ -185,7 +185,7 @@ class SendEmailOrchestrator:
 		# Prefer SMTP
 		if self.SmtpService is not None:
 			await self.SmtpService.send(
-				email_from,
+				email_from=email_from,
 				email_to=email_to,
 				email_cc=email_cc,
 				email_bcc=email_bcc,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send pre-rendered/raw email content (HTML or text) with CC, BCC and attachments; uses configured SMTP or Microsoft 365 providers and errors clearly if none are configured.

* **Improvements**
  * More robust SMTP configuration and service registration.
  * Slack and SMS now enable based on their own configurations.
  * Error notifications now send HTML raw emails and use a safe fallback subject.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->