### PR TITLE
SMTP certificate Bundle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ validate_certs  = yes                 ; Verify server certificate (recommended i
 cert_bundle     =                     ; Path to CA/chain PEM when validate_certs=yes.
                                       ; Needed for self-signed/internal CAs.
                                       ; Leave empty to use system trust store.
+                                      ; When validate_certs=no, both chain and hostname checks are disabled and
+                                      ; cert_bundle is ignored.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ cert_bundle     =                     ; Path to CA/chain PEM when validate_certs
 ```ini
 [smtp]
 host            = mail.internal.lan
+user            = admin
 port            = 465
 ssl             = yes
 starttls        = no
@@ -143,6 +144,7 @@ cert_bundle     = /etc/ssl/internal_ca.pem
 ```ini
 [smtp]
 host            = smtp.example.com
+user            = admin
 port            = 587
 ssl             = no
 starttls        = yes
@@ -157,6 +159,7 @@ cert_bundle     =                    ; empty = use system trust store
 ```ini
 [smtp]
 host            = 127.0.0.1
+user            = admin
 port            = 2525
 ssl             = no
 starttls        = no

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ host            = mail.internal.lan
 port            = 465
 ssl             = yes
 starttls        = no
-user            = service
 password        = ****
 from            = noreply@internal.lan
 validate_certs  = yes
@@ -145,7 +144,6 @@ host            = smtp.example.com
 port            = 587
 ssl             = no
 starttls        = yes
-user            = service
 password        = ****
 from            = noreply@example.com
 validate_certs  = yes
@@ -160,19 +158,11 @@ host            = 127.0.0.1
 port            = 2525
 ssl             = no
 starttls        = no
-user            =
 password        =
 from            = dev@localhost
 validate_certs  = no
 cert_bundle     =
 ```
-
-**Troubleshooting**
-
-* **`TLSV1_ALERT_UNKNOWN_CA`** ⇒ `cert_bundle` missing/wrong. Point to the issuing CA/chain PEM.
-* **`SSLV3_ALERT_HANDSHAKE_FAILURE` / `WRONG_VERSION_NUMBER`** ⇒ mode/port mismatch or server policy. Use 465+`ssl=yes` **or** 587+`starttls=yes` (not both).
-* **Hostname mismatch** ⇒ connect using the hostname in the cert’s SAN/CN (not an IP).
-
 
 ### 🚨 2. Sending Slack messages
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,90 @@ markdown_wrapper=/Templates/Email/body_wrapper.html
 - `markdown_wrapper`: Specifies the path to the HTML template for wrapping email content.
 If this configuration is not provided, or if the value is left empty, the markdown_wrapper will default to None. In such cases, Markdown-formatted emails will be sent without any additional HTML wrapping. This means the emails will consist solely of the content converted from Markdown to HTML, without any extra styling or structure provided by a wrapper template.
 
+## 🔐 SMTP Transport & TLS Verification
+
+**Keys (under `[smtp]`)**
+
+```ini
+# Transport
+host            = smtp.example.com
+port            = 465                 ; 465 = implicit TLS (SMTPS), 587 = STARTTLS
+user            = admin
+password        = secret
+from            = info@example.com
+
+# TLS mode (choose ONE)
+ssl             = yes                 ; yes => implicit TLS (465)
+starttls        = no                  ; yes => STARTTLS (587). Do NOT enable both.
+
+# Verification
+validate_certs  = yes                 ; Verify server certificate (recommended in prod)
+cert_bundle     =                     ; Path to CA/chain PEM when validate_certs=yes.
+                                      ; Needed for self-signed/internal CAs.
+                                      ; Leave empty to use system trust store.
+
+```
+
+**Important**
+
+* Use real booleans: `yes|no` (not quoted strings).
+* `cert_bundle` must be a **CA/chain PEM**, **not** the server cert.
+* If you supply a custom TLS context in code, some clients ignore `validate_certs`/`cert_bundle`.
+
+**Common Setups**
+
+**A) Production — SMTPS (465) with internal CA**
+
+```ini
+[smtp]
+host            = mail.internal.lan
+port            = 465
+ssl             = yes
+starttls        = no
+user            = service
+password        = ****
+from            = noreply@internal.lan
+validate_certs  = yes
+cert_bundle     = /etc/ssl/internal_ca.pem
+```
+
+**B) Production — STARTTLS (587) with public CA**
+
+```ini
+[smtp]
+host            = smtp.example.com
+port            = 587
+ssl             = no
+starttls        = yes
+user            = service
+password        = ****
+from            = noreply@example.com
+validate_certs  = yes
+cert_bundle     =                    ; empty = use system trust store
+```
+
+**C) Local Dev — no TLS (not for prod)**
+
+```ini
+[smtp]
+host            = 127.0.0.1
+port            = 2525
+ssl             = no
+starttls        = no
+user            =
+password        =
+from            = dev@localhost
+validate_certs  = no
+cert_bundle     =
+```
+
+**Troubleshooting**
+
+* **`TLSV1_ALERT_UNKNOWN_CA`** ⇒ `cert_bundle` missing/wrong. Point to the issuing CA/chain PEM.
+* **`SSLV3_ALERT_HANDSHAKE_FAILURE` / `WRONG_VERSION_NUMBER`** ⇒ mode/port mismatch or server policy. Use 465+`ssl=yes` **or** 587+`starttls=yes` (not both).
+* **Hostname mismatch** ⇒ connect using the hostname in the cert’s SAN/CN (not an IP).
+
+
 ### 🚨 2. Sending Slack messages
 
 **Overview**

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -156,6 +156,9 @@ class ASABIRISApplication(asab.Application):
 
 		self.WebHandler = WebHandler(self)
 
+		# Apache Kafka API is conditional
+		if "kafka" in asab.Config.sections():
+			self.KafkaHandler = KafkaHandler(self)
 
 
 	def enabled_orchestrators(self):

--- a/asabiris/app.py
+++ b/asabiris/app.py
@@ -156,9 +156,6 @@ class ASABIRISApplication(asab.Application):
 
 		self.WebHandler = WebHandler(self)
 
-		# Apache Kafka API is conditional
-		if "kafka" in asab.Config.sections():
-			self.KafkaHandler = KafkaHandler(self)
 
 
 	def enabled_orchestrators(self):

--- a/asabiris/orchestration/sendemail.py
+++ b/asabiris/orchestration/sendemail.py
@@ -82,7 +82,7 @@ class SendEmailOrchestrator:
 		if self.SmtpService is not None:
 			atts_gen = self.AttachmentRenderingService.render_attachment(attachments)
 			await self.SmtpService.send(
-				email_from,
+				email_from=email_from,
 				email_to=email_to,
 				email_cc=email_cc,
 				email_bcc=email_bcc,

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -132,9 +132,6 @@ class EmailOutputService(asab.Service, OutputABC):
 					filename=attachment.FileName
 				)
 
-		L.warning("SMTP cfg host='{}' port='{}' ssl='{}' starttls='{}' validate_certs='{}' cert_bundle='{}'".format(
-			self.Host, self.Port, self.SSL, self.StartTLS, self.ValidateCerts, self.Cert
-		))
 		# Send the email with retry logic
 		retry_attempts = 3
 		delay = 5  # seconds

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -151,10 +151,8 @@ class EmailOutputService(asab.Service, OutputABC):
 					password=self.Password,
 					use_tls=self.SSL,
 					start_tls=self.StartTLS,
-					cert_bundle=self.Cert or None, # server bundles
-					# client_cert='/Users/mithunshivashankar/PycharmProjects/asab-iris/etc/smtp-client-cert.pem',
-					# client_key ='/Users/mithunshivashankar/PycharmProjects/asab-iris/etc/smtp-client-key.pem',
-					validate_certs=self.ValidateCerts,  # <-- use config
+					cert_bundle=self.Cert or None,
+					validate_certs=self.ValidateCerts
 				)
 				L.log(asab.LOG_NOTICE, "Email sent", struct_data={'result': result[1], "host": self.Host})
 				break  # Email sent successfully, exit the retry loop

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -49,6 +49,7 @@ class EmailOutputService(asab.Service, OutputABC):
 		self.Password = asab.Config.get(config_section_name, "password")
 
 		self.Sender = asab.Config.get(config_section_name, "from")
+		self.Subject = asab.Config.get(config_section_name, "subject")
 		self.ValidateCerts = asab.Config.getboolean(config_section_name, "validate_certs", fallback=True)
 		self.Cert = asab.Config.get(config_section_name, "cert_bundle", fallback="").strip()
 

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -142,7 +142,7 @@ class EmailOutputService(asab.Service, OutputABC):
 				result = await aiosmtplib.send(
 					msg,
 					sender=sender,
-					recipients=(email_to or []) + (email_cc or []) + (email_bcc or []),
+					recipients=email_to + email_cc + email_bcc,
 					hostname=self.Host,
 					port=int(self.Port) if self.Port != "" else None,
 					username=self.User,

--- a/etc/asab-iris.conf
+++ b/etc/asab-iris.conf
@@ -10,6 +10,13 @@ from=info@example.com
 ssl=no
 starttls=yes
 subject=Mail from ASAB Iris
+validate_certs=false   # DEV-ONLY: skip TLS cert verification. Connection is encrypted but NOT trusted; vulnerable to MITM.
+
+cert_bundle=           # Path to CA bundle (PEM) used when validate_certs=true.
+                       # Needed for self-signed/internal CAs (put your CA/chain here).
+                       # Leave empty to use system trust store.
+                       # Ignored if validate_certs=false.
+
 
 [slack]
 # Configure the integration with Slack


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SMTP TLS verification controls and support for supplying a custom CA bundle.
  * Email delivery now consolidates To, Cc, and Bcc recipients when sending.

* **Configuration**
  * New SMTP settings: validate_certs (toggle cert verification) and cert_bundle (CA bundle path), with sensible defaults and support for SMTPS/STARTTLS.

* **Documentation**
  * Expanded README with SMTP/TLS setup guidance, examples, and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->