### PR TITLE
Retry Kafka consumer with alternate bootstrap servers

### DIFF
--- a/asabiris/handlers/kafkahandler.py
+++ b/asabiris/handlers/kafkahandler.py
@@ -104,7 +104,8 @@ class KafkaHandler(asab.Service):
 				await self.Consumer.start()
 				break
 
-			except (aiokafka.errors.KafkaConnectionError, aiokafka.errors.NoBrokersAvailable) as e:
+
+			except (aiokafka.errors.KafkaConnectionError, aiokafka.errors.KafkaError) as e:
 				L.warning(
 					"No connection to Kafka established. Attempt {} of {}. Retrying in {} seconds... {}".format(
 						attempt + 1, max_retries, delay, e


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka connection reliability with enhanced retry logic that rotates across brokers on each reconnection attempt.
  * Added validation to skip initialization when required Kafka configuration is missing.
  * Enhanced error handling and logging for broker unavailability and connection errors.
  * Ensured stale consumers are replaced so fresh consumer instances are used during retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->