### PR TITLE
Add HTTP CONNECT proxy support to SMTP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ cert_bundle     =                     ; Path to CA/chain PEM when validate_certs
                                       ; When validate_certs=no, both chain and hostname checks are disabled and
                                       ; cert_bundle is ignored.
 
+# Optional HTTP CONNECT proxy for SMTP transport
+proxy_host      =                     ; e.g. proxy.company.local
+proxy_port      =                     ; e.g. 3128
+proxy_user      =                     ; Optional basic-auth username
+proxy_password  =                     ; Optional basic-auth password
+proxy_connect_timeout = 10            ; Proxy TCP/CONNECT timeout (seconds)
+
 ```
 
 **Important**
@@ -190,6 +197,7 @@ cert_bundle     =                     ; Path to CA/chain PEM when validate_certs
 * Use real booleans: `yes|no` (not quoted strings).
 * `cert_bundle` must be a **CA/chain PEM**, **not** the server cert.
 * If you supply a custom TLS context in code, some clients ignore `validate_certs`/`cert_bundle`.
+* Proxy support uses **HTTP CONNECT** (not SOCKS) and is enabled only when both `proxy_host` and `proxy_port` are set.
 
 **Common Setups**
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ proxy_host      =                     ; e.g. proxy.company.local
 proxy_port      =                     ; e.g. 3128
 proxy_user      =                     ; Optional basic-auth username
 proxy_password  =                     ; Optional basic-auth password
-proxy_connect_timeout = 10            ; Proxy TCP/CONNECT timeout (seconds)
+proxy_connect_timeout = 10            ; Proxy TCP/CONNECT timeout only (seconds)
+                                      ; Does not change SMTP EHLO/TLS/AUTH/DATA timeouts.
 
 ```
 
@@ -198,6 +199,9 @@ proxy_connect_timeout = 10            ; Proxy TCP/CONNECT timeout (seconds)
 * `cert_bundle` must be a **CA/chain PEM**, **not** the server cert.
 * If you supply a custom TLS context in code, some clients ignore `validate_certs`/`cert_bundle`.
 * Proxy support uses **HTTP CONNECT** (not SOCKS) and is enabled only when both `proxy_host` and `proxy_port` are set.
+* If `proxy_user` is set, ASAB Iris sends `Proxy-Authorization: Basic ...` during CONNECT.
+* Proxy mode supports plain SMTP, STARTTLS, and implicit TLS (SMTPS) with normal certificate validation.
+* `proxy_connect_timeout` applies only to connecting to the proxy and completing the HTTP CONNECT handshake.
 
 **Common Setups**
 
@@ -244,6 +248,26 @@ password        =
 from            = dev@localhost
 validate_certs  = no
 cert_bundle     =
+```
+
+**D) SMTPS (465) through an HTTP CONNECT proxy**
+
+```ini
+[smtp]
+host            = mail.internal.lan
+user            = admin
+port            = 465
+ssl             = yes
+starttls        = no
+password        = ****
+from            = noreply@internal.lan
+validate_certs  = yes
+cert_bundle     = /etc/ssl/internal_ca.pem
+proxy_host      = proxy.company.local
+proxy_port      = 3128
+proxy_user      = proxy-user         ; optional
+proxy_password  = ****               ; optional
+proxy_connect_timeout = 10
 ```
 
 ### 🚨 2. Sending Slack messages

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -55,60 +55,14 @@ class WebHandler(object):
 	@asab.web.rest.json_schema_handler(email_schema)
 	async def send_email(self, request, *, json_data):
 		"""
-		This endpoint is for sending emails.
-		```
-		1) It collects the basic email info (to, cc, bcc, subject, from)
-		2) It renders the email body based on the template
-		3) Optionally it adds attachments:
+		Send one email defined by the request JSON payload.
 
-			3.1) The attachment is renders by this service.
+		The request contract covers message content only: recipients, subject, sender,
+		body template, and optional attachments. Transport behavior such as direct SMTP,
+		SMTP via HTTP CONNECT proxy, or MS365 is selected by server-side configuration.
 
-			3.2) The attachment is provided by the caller.
-
-		```
-		Example body:
-
-		```
-		{
-			"to": ['Tony.Montana@Goodfellas.com'],
-			"cc": ['Jimmy2.times@Goodfellas.com'],
-			"bcc": ['Henry.Hill@Goodfellas.com'],
-			"subject": "Lufthansa Hiest",
-			"from": "Jimmy.Conway@Goodfellas.com",
-			"body": {
-				"template": "/Templates/Emails/test.md",
-				"params": {
-					"Name": "Toddy Siciro"
-			}
-		},
-		"attachments": [
-			{
-			"template": "/Templates/Emails/hello.html",
-			"params": {
-				"Name": "Michael Corleone"
-				},
-			"format": "pdf",
-			"filename": "Alert.pdf"
-			}]
-		}
-
-		```
-		Attached will be retrieved from request. Content when rendering the email is not required.
-
-		Example of the email body template:
-		```
-		SUBJECT: Automated email for {{name}}
-
-		Hi {{name}},
-
-		this is a nice template for an email.
-		It is {{time}} to leave.
-
-		Br,
-		Your automated ASAB report
-		```
-
-		It is a markdown template.
+		Body templates must live under `/Templates/Email/`.
+		Attachment templates must live under `/Templates/Attachment/`.
 		---
 		tags: ['Send mail']
 		"""
@@ -117,12 +71,11 @@ class WebHandler(object):
 	@asab.web.tenant.allow_no_tenant
 	async def send_email_jsonata(self, request):
 		"""
-		This endpoint is for sending emails - JSONata template is applied first to the request body.
+		Apply a JSONata template to the request body, then forward the result to
+		`/send_email`.
 
-		It applies JSONata template (stored in `/Templates/JSONata`) to the request body and then the output is used as a body to /send_email endpoint.
-		It allows to transform arbitrary JSON data into a valid email body.
-
-		Build the JSONata template at https://try.jsonata.org
+		JSONata templates are stored under `/Templates/JSONata/` and must produce an
+		object compatible with the `/send_email` request contract.
 		"""
 		jsonata_template = request.match_info["jsonata"]
 		assert '..' not in jsonata_template, "JSONata template cannot contain '..'"

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -55,22 +55,65 @@ class WebHandler(object):
 		}
 		return asab.web.rest.json_response(request, response)
 
-	@asab.web.tenant.allow_no_tenant
-	@asab.web.rest.json_schema_handler(email_schema)
-	async def send_email(self, request, *, json_data):
-		"""
-		Send one email defined by the request JSON payload.
+		@asab.web.tenant.allow_no_tenant
+		@asab.web.rest.json_schema_handler(email_schema)
+		async def send_email(self, request, *, json_data):
+			"""
+			Send one email defined by the request JSON payload.
 
-		The request contract covers message content only: recipients, subject, sender,
-		body template, and optional attachments. Transport behavior such as direct SMTP,
-		SMTP via HTTP CONNECT proxy, or MS365 is selected by server-side configuration.
+			The request contract covers message content only:
+			1. collect recipients and optional headers (`to`, `cc`, `bcc`, `subject`, `from`)
+			2. render the email body from a template under `/Templates/Email/`
+			3. optionally render or attach files from `/Templates/Attachment/` or caller-supplied Base64 content
 
-		Body templates must live under `/Templates/Email/`.
-		Attachment templates must live under `/Templates/Attachment/`.
-		---
-		tags: ['Send mail']
-		"""
-		return await self._send_email(request, json_data)
+			Transport behavior such as direct SMTP, SMTP via HTTP CONNECT proxy, or MS365
+			is selected by server-side configuration and is not part of the request body.
+
+			Example body:
+
+			```json
+			{
+			  "to": ["tony.montana@goodfellas.com"],
+			  "cc": ["jimmy.conway@goodfellas.com"],
+			  "bcc": ["henry.hill@goodfellas.com"],
+			  "subject": "Lufthansa Heist",
+			  "from": "jimmy.conway@goodfellas.com",
+			  "body": {
+			    "template": "/Templates/Email/test.md",
+			    "params": {
+			      "name": "Toddy Siciro"
+			    }
+			  },
+			  "attachments": [
+			    {
+			      "template": "/Templates/Attachment/hello.html",
+			      "params": {
+			        "name": "Michael Corleone"
+			      },
+			      "format": "pdf",
+			      "filename": "Alert.pdf"
+			    }
+			  ]
+			}
+			```
+
+			Example of an email body template:
+
+			```text
+			SUBJECT: Automated email for {{name}}
+
+			Hi {{name}},
+
+			This is a nice template for an email.
+			It is {{time}} to leave.
+
+			Br,
+			Your automated ASAB report
+			```
+			---
+			tags: ['Send mail']
+			"""
+			return await self._send_email(request, json_data)
 
 	@asab.web.tenant.allow_no_tenant
 	async def send_email_jsonata(self, request):

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -73,27 +73,27 @@ class WebHandler(object):
 
 			```json
 			{
-			  "to": ["tony.montana@goodfellas.com"],
-			  "cc": ["jimmy.conway@goodfellas.com"],
-			  "bcc": ["henry.hill@goodfellas.com"],
-			  "subject": "Lufthansa Heist",
-			  "from": "jimmy.conway@goodfellas.com",
-			  "body": {
-			    "template": "/Templates/Email/test.md",
-			    "params": {
-			      "name": "Toddy Siciro"
-			    }
-			  },
-			  "attachments": [
-			    {
-			      "template": "/Templates/Attachment/hello.html",
-			      "params": {
-			        "name": "Michael Corleone"
-			      },
-			      "format": "pdf",
-			      "filename": "Alert.pdf"
-			    }
-			  ]
+				"to": ["tony.montana@goodfellas.com"],
+				"cc": ["jimmy.conway@goodfellas.com"],
+				"bcc": ["henry.hill@goodfellas.com"],
+				"subject": "Lufthansa Heist",
+				"from": "jimmy.conway@goodfellas.com",
+				"body": {
+					"template": "/Templates/Email/test.md",
+					"params": {
+						"name": "Toddy Siciro"
+					}
+				},
+				"attachments": [
+					{
+						"template": "/Templates/Attachment/hello.html",
+						"params": {
+							"name": "Michael Corleone"
+						},
+						"format": "pdf",
+						"filename": "Alert.pdf"
+					}
+				]
 			}
 			```
 

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -70,11 +70,21 @@ class EmailOutputService(asab.Service, OutputABC):
 		self.ProxyUser = asab.Config.get(config_section_name, "proxy_user", fallback="").strip()
 		self.ProxyPassword = asab.Config.get(config_section_name, "proxy_password", fallback="")
 		self.ProxyConnectTimeout = asab.Config.getint(config_section_name, "proxy_connect_timeout", fallback=10)
+		self.ProxyPortInt = None
 
 		if self.ProxyHost and not self.ProxyPort:
 			raise ValueError("SMTP proxy is configured but `proxy_port` is empty")
 		if self.ProxyPort and not self.ProxyHost:
 			raise ValueError("SMTP proxy is configured but `proxy_host` is empty")
+		if self.ProxyPort:
+			try:
+				self.ProxyPortInt = int(self.ProxyPort)
+			except ValueError as e:
+				raise ValueError("SMTP proxy `proxy_port` must be an integer: {}".format(str(e)))
+			if self.ProxyPortInt < 1 or self.ProxyPortInt > 65535:
+				raise ValueError("SMTP proxy `proxy_port` must be in range 1..65535")
+		if self.ProxyConnectTimeout <= 0:
+			raise ValueError("SMTP proxy `proxy_connect_timeout` must be greater than 0")
 
 		if len(self.User) == 0:
 			self.User = None
@@ -369,6 +379,8 @@ class EmailOutputService(asab.Service, OutputABC):
 		try:
 			client = aiosmtplib.SMTP(
 				sock=proxy_socket,
+				hostname=None,
+				port=None,
 				use_tls=self.SSL,
 				start_tls=False,
 				validate_certs=self.ValidateCerts,
@@ -433,11 +445,7 @@ class EmailOutputService(asab.Service, OutputABC):
 	async def _connect_via_http_proxy(self):
 		target_host = self.Host
 		target_port = self._effective_smtp_port()
-
-		try:
-			proxy_port = int(self.ProxyPort)
-		except ValueError as e:
-			raise ProxyConnectError("Invalid proxy_port '{}': {}".format(self.ProxyPort, str(e)))
+		proxy_port = self.ProxyPortInt if self.ProxyPortInt is not None else 0
 
 		sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		sock_obj.setblocking(False)

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -230,7 +230,6 @@ class EmailOutputService(asab.Service, OutputABC):
 		delay = 5  # seconds
 
 		for attempt in range(retry_attempts):
-			proxy_socket = None
 			try:
 				if self.ProxyHost:
 					result = await self._send_via_proxy_smtp_client(
@@ -261,7 +260,11 @@ class EmailOutputService(asab.Service, OutputABC):
 					struct_data={"proxy_host": self.ProxyHost, "proxy_port": self.ProxyPort, "host": self.Host}
 				)
 				if attempt < retry_attempts - 1:
-					L.info("Retrying email send after proxy connection failure, attempt {}".format(attempt + 1))
+					L.log(
+						asab.LOG_NOTICE,
+						"Retrying email send after proxy connection failure",
+						struct_data={"attempt": attempt + 1, "proxy_host": self.ProxyHost, "proxy_port": self.ProxyPort, "host": self.Host}
+					)
 					await asyncio.sleep(delay)
 					continue
 				raise ASABIrisError(
@@ -356,12 +359,6 @@ class EmailOutputService(asab.Service, OutputABC):
 						"host": self.Host
 					}
 				)
-			finally:
-				if proxy_socket is not None:
-					try:
-						proxy_socket.close()
-					except OSError:
-						pass
 
 	async def _send_via_proxy_smtp_client(self, *, msg, sender, recipients):
 		if self.SSL and self.ValidateCerts:
@@ -374,6 +371,8 @@ class EmailOutputService(asab.Service, OutputABC):
 				error_i18n_key="Unsupported SMTP proxy TLS configuration."
 			)
 
+		# Proxy mode cannot reuse the normal hostname/port connect path. We first create a
+		# dedicated socket to the proxy, establish the CONNECT tunnel, and then run SMTP on it.
 		proxy_socket = await self._connect_via_http_proxy()
 		client = None
 		try:

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -221,27 +221,26 @@ class EmailOutputService(asab.Service, OutputABC):
 		for attempt in range(retry_attempts):
 			proxy_socket = None
 			try:
-				send_kwargs = {
-					"sender": sender,
-					"recipients": to_recipients + cc_recipients + bcc_recipients,
-					"username": self.User,
-					"password": self.Password,
-					"use_tls": self.SSL,
-					"start_tls": self.StartTLS,
-					"cert_bundle": self.Cert or None,
-					"validate_certs": self.ValidateCerts,
-				}
-
 				if self.ProxyHost:
-					proxy_socket = await self._connect_via_http_proxy()
-					send_kwargs["sock"] = proxy_socket
-					send_kwargs["hostname"] = None
-					send_kwargs["port"] = None
+					result = await self._send_via_proxy_smtp_client(
+						msg=msg,
+						sender=sender,
+						recipients=to_recipients + cc_recipients + bcc_recipients
+					)
 				else:
-					send_kwargs["hostname"] = self.Host
-					send_kwargs["port"] = int(self.Port) if self.Port != "" else None
-
-				result = await aiosmtplib.send(msg, **send_kwargs)
+					result = await aiosmtplib.send(
+						msg,
+						sender=sender,
+						recipients=to_recipients + cc_recipients + bcc_recipients,
+						hostname=self.Host,
+						port=int(self.Port) if self.Port != "" else None,
+						username=self.User,
+						password=self.Password,
+						use_tls=self.SSL,
+						start_tls=self.StartTLS,
+						cert_bundle=self.Cert or None,
+						validate_certs=self.ValidateCerts
+					)
 				L.log(asab.LOG_NOTICE, "Email sent", struct_data={'result': result[1], "host": self.Host})
 				break  # Email sent successfully, exit the retry loop
 
@@ -262,6 +261,8 @@ class EmailOutputService(asab.Service, OutputABC):
 						"host": self.Host,
 					}
 				)
+			except ASABIrisError:
+				raise
 			except aiosmtplib.errors.SMTPConnectError as e:
 				L.warning("Connection failed: {}".format(e), struct_data={"host": self.Host, "port": self.Port})
 				if attempt < retry_attempts - 1:
@@ -350,6 +351,48 @@ class EmailOutputService(asab.Service, OutputABC):
 						proxy_socket.close()
 					except OSError:
 						pass
+
+	async def _send_via_proxy_smtp_client(self, *, msg, sender, recipients):
+		if self.SSL and self.ValidateCerts:
+			raise ASABIrisError(
+				ErrorCode.INVALID_SERVICE_CONFIGURATION,
+				tech_message=(
+					"Proxy with implicit TLS and certificate validation is not supported with current SMTP client "
+					"version. Use STARTTLS or disable certificate validation."
+				),
+				error_i18n_key="Unsupported SMTP proxy TLS configuration."
+			)
+
+		proxy_socket = await self._connect_via_http_proxy()
+		client = None
+		try:
+			client = aiosmtplib.SMTP(
+				sock=proxy_socket,
+				use_tls=self.SSL,
+				start_tls=False,
+				validate_certs=self.ValidateCerts,
+				cert_bundle=self.Cert or None,
+				timeout=self.ProxyConnectTimeout
+			)
+			await client.connect()
+
+			if self.StartTLS:
+				await client.starttls(server_hostname=self.Host)
+
+			if self.User is not None:
+				await client.login(self.User, self.Password or "")
+
+			return await client.send_message(msg, sender=sender, recipients=recipients)
+		finally:
+			if client is not None:
+				try:
+					await client.quit()
+				except Exception:
+					pass
+			try:
+				proxy_socket.close()
+			except Exception:
+				pass
 
 	def _effective_smtp_port(self):
 		if self.Port != "":

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -420,7 +420,9 @@ class EmailOutputService(asab.Service, OutputABC):
 		buffer = b""
 		max_headers_size = 65536
 		while b"\r\n\r\n" not in buffer:
-			chunk = await loop.sock_recv(sock_obj, 4096)
+			# Read byte-by-byte to avoid consuming bytes from the next protocol (SMTP)
+			# that may already be available in the socket buffer after CONNECT headers.
+			chunk = await loop.sock_recv(sock_obj, 1)
 			if not chunk:
 				raise ProxyConnectError("Proxy closed connection before CONNECT response")
 			buffer += chunk

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -9,6 +9,15 @@ import asab
 import asab.contextvars
 import asyncio
 import aiosmtplib
+from aiosmtplib.compat import create_connection, create_unix_connection
+from aiosmtplib.errors import (
+	SMTPConnectError,
+	SMTPConnectTimeoutError,
+	SMTPServerDisconnected,
+	SMTPTimeoutError,
+)
+from aiosmtplib.protocol import SMTPProtocol
+from aiosmtplib.status import SMTPStatus
 
 from ...output_abc import OutputABC
 from ...errors import ASABIrisError, ErrorCode
@@ -20,6 +29,123 @@ L = logging.getLogger(__name__)
 
 class ProxyConnectError(Exception):
 	pass
+
+
+class ProxySMTP(aiosmtplib.SMTP):
+	"""
+	Proxy CONNECT gives us an already-connected socket, but we still need the original
+	SMTP hostname for implicit TLS SNI and certificate validation.
+	"""
+
+	def _validate_config(self):
+		if self._start_tls_on_connect and self.use_tls:
+			raise ValueError("The start_tls and use_tls options are not compatible.")
+
+		if self.tls_context is not None and self.client_cert is not None:
+			raise ValueError(
+				"Either a TLS context or a certificate/key must be provided"
+			)
+
+		if self.sock is not None and self.socket_path is not None:
+			raise ValueError(
+				"The socket option is not compatible with socket_path"
+			)
+
+		if self.socket_path is not None and any([self.hostname, self.port]):
+			raise ValueError(
+				"The socket_path option is not compatible with hostname/port"
+			)
+
+		if self.source_address is not None and (
+			"\r" in self.source_address or "\n" in self.source_address
+		):
+			raise ValueError(
+				"The source_address param contains prohibited newline characters"
+			)
+
+		if self.hostname is not None and (
+			"\r" in self.hostname or "\n" in self.hostname
+		):
+			raise ValueError(
+				"The hostname param contains prohibited newline characters"
+			)
+
+	async def _create_connection(self):
+		if self.loop is None:
+			raise RuntimeError("No event loop set")
+
+		protocol = SMTPProtocol(
+			loop=self.loop, connection_lost_callback=self._connection_lost
+		)
+
+		tls_context = None
+		ssl_handshake_timeout = None
+		if self.use_tls:
+			tls_context = self._get_tls_context()
+			ssl_handshake_timeout = self.timeout
+
+		if self.sock:
+			connect_coro = create_connection(
+				self.loop,
+				lambda: protocol,
+				sock=self.sock,
+				ssl=tls_context,
+				server_hostname=self.hostname if self.use_tls else None,
+				ssl_handshake_timeout=ssl_handshake_timeout,
+			)
+		elif self.socket_path:
+			connect_coro = create_unix_connection(
+				self.loop,
+				lambda: protocol,
+				path=self.socket_path,
+				ssl=tls_context,
+				ssl_handshake_timeout=ssl_handshake_timeout,
+			)
+		else:
+			connect_coro = create_connection(
+				self.loop,
+				lambda: protocol,
+				host=self.hostname,
+				port=self.port,
+				ssl=tls_context,
+				ssl_handshake_timeout=ssl_handshake_timeout,
+			)
+
+		try:
+			transport, _ = await asyncio.wait_for(connect_coro, timeout=self.timeout)
+		except OSError as exc:
+			raise SMTPConnectError(
+				"Error connecting to {host} on port {port}: {err}".format(
+					host=self.hostname, port=self.port, err=exc
+				)
+			) from exc
+		except asyncio.TimeoutError as exc:
+			raise SMTPConnectTimeoutError(
+				"Timed out connecting to {host} on port {port}".format(
+					host=self.hostname, port=self.port
+				)
+			) from exc
+
+		self.protocol = protocol
+		self.transport = transport
+
+		try:
+			response = await protocol.read_response(timeout=self.timeout)
+		except SMTPServerDisconnected as exc:
+			raise SMTPConnectError(
+				"Error connecting to {host} on port {port}: {err}".format(
+					host=self.hostname, port=self.port, err=exc
+				)
+			) from exc
+		except SMTPTimeoutError as exc:
+			raise SMTPConnectTimeoutError(
+				"Timed out waiting for server ready message"
+			) from exc
+
+		if response.code != SMTPStatus.ready:
+			raise SMTPConnectError(str(response))
+
+		return response
 
 
 #
@@ -109,6 +235,10 @@ class EmailOutputService(asab.Service, OutputABC):
 	):
 		"""
 		Send an outgoing email with the given parameters.
+
+		Transport selection is transparent to callers. The request contract stays the
+		same regardless of whether the server is configured for direct SMTP, SMTP via
+		an HTTP CONNECT proxy, or a different provider.
 
 		:param to: To whom the email is being sent
 		:type to: list of strings (email addresses)
@@ -361,30 +491,29 @@ class EmailOutputService(asab.Service, OutputABC):
 				)
 
 	async def _send_via_proxy_smtp_client(self, *, msg, sender, recipients):
-		if self.SSL and self.ValidateCerts:
-			raise ASABIrisError(
-				ErrorCode.INVALID_SERVICE_CONFIGURATION,
-				tech_message=(
-					"Proxy with implicit TLS and certificate validation is not supported with current SMTP client "
-					"version. Use STARTTLS or disable certificate validation."
-				),
-				error_i18n_key="Unsupported SMTP proxy TLS configuration."
-			)
+		"""
+		Send one SMTP message through an HTTP CONNECT tunnel.
 
+		The tunnel setup uses proxy-specific configuration, but once established the
+		SMTP session should behave like the direct path, including normal SMTP
+		timeouts and TLS validation.
+		"""
 		# Proxy mode cannot reuse the normal hostname/port connect path. We first create a
 		# dedicated socket to the proxy, establish the CONNECT tunnel, and then run SMTP on it.
+		target_port = self._effective_smtp_port()
 		proxy_socket = await self._connect_via_http_proxy()
 		client = None
 		try:
-			client = aiosmtplib.SMTP(
+			# Keep the regular SMTP client timeout semantics. proxy_connect_timeout only
+			# applies to the TCP/CONNECT tunnel setup done in _connect_via_http_proxy().
+			client = ProxySMTP(
 				sock=proxy_socket,
-				hostname=None,
-				port=None,
+				hostname=self.Host,
+				port=target_port,
 				use_tls=self.SSL,
 				start_tls=False,
 				validate_certs=self.ValidateCerts,
 				cert_bundle=self.Cert or None,
-				timeout=self.ProxyConnectTimeout
 			)
 			await client.connect()
 
@@ -416,6 +545,9 @@ class EmailOutputService(asab.Service, OutputABC):
 		return 25
 
 	def _proxy_connect_headers(self, target_host, target_port):
+		"""
+		Build the HTTP CONNECT request sent to the proxy.
+		"""
 		headers = [
 			"CONNECT {}:{} HTTP/1.1".format(target_host, target_port),
 			"Host: {}:{}".format(target_host, target_port),
@@ -427,6 +559,9 @@ class EmailOutputService(asab.Service, OutputABC):
 		return "\r\n".join(headers) + "\r\n\r\n"
 
 	async def _read_http_headers(self, sock_obj):
+		"""
+		Read proxy response headers without consuming bytes from the SMTP stream.
+		"""
 		loop = asyncio.get_running_loop()
 		buffer = b""
 		max_headers_size = 65536
@@ -442,6 +577,9 @@ class EmailOutputService(asab.Service, OutputABC):
 		return buffer.split(b"\r\n\r\n", 1)[0]
 
 	async def _connect_via_http_proxy(self):
+		"""
+		Open a TCP connection to the proxy and establish an HTTP CONNECT tunnel.
+		"""
 		target_host = self.Host
 		target_port = self._effective_smtp_port()
 		proxy_port = self.ProxyPortInt if self.ProxyPortInt is not None else 0

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -174,7 +174,7 @@ class EmailOutputService(asab.Service, OutputABC):
 		cc_recipients = []
 		bcc_recipients = []
 
-		if email_cc is not None:
+		if email_cc:
 			assert isinstance(email_cc, list)
 			formatted_email_cc = []
 			for email_address in email_cc:
@@ -182,7 +182,8 @@ class EmailOutputService(asab.Service, OutputABC):
 				if sender_email:
 					formatted_email_cc.append(sender_email)
 					cc_recipients.append(sender_email)
-			msg['Cc'] = ', '.join(formatted_email_cc)
+			if formatted_email_cc:
+				msg['Cc'] = ', '.join(formatted_email_cc)
 
 		if email_bcc is not None:
 			assert isinstance(email_bcc, list)

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -1,7 +1,9 @@
 import email
 import email.message
+import base64
 import logging
 import re
+import socket
 
 import asab
 import asab.contextvars
@@ -14,6 +16,11 @@ from ...errors import ASABIrisError, ErrorCode
 #
 
 L = logging.getLogger(__name__)
+
+
+class ProxyConnectError(Exception):
+	pass
+
 
 #
 asab.Config.add_defaults(
@@ -30,6 +37,11 @@ asab.Config.add_defaults(
 			"message_body": "",
 			"validate_certs": "true",  # NEW
 			"cert_bundle": "",  # NEW
+			"proxy_host": "",
+			"proxy_port": "",
+			"proxy_user": "",
+			"proxy_password": "",
+			"proxy_connect_timeout": "10",
 		}
 	})
 
@@ -53,6 +65,16 @@ class EmailOutputService(asab.Service, OutputABC):
 		self.Subject = asab.Config.get(config_section_name, "subject")
 		self.ValidateCerts = asab.Config.getboolean(config_section_name, "validate_certs", fallback=True)
 		self.Cert = asab.Config.get(config_section_name, "cert_bundle", fallback="").strip()
+		self.ProxyHost = asab.Config.get(config_section_name, "proxy_host", fallback="").strip()
+		self.ProxyPort = asab.Config.get(config_section_name, "proxy_port", fallback="").strip()
+		self.ProxyUser = asab.Config.get(config_section_name, "proxy_user", fallback="").strip()
+		self.ProxyPassword = asab.Config.get(config_section_name, "proxy_password", fallback="")
+		self.ProxyConnectTimeout = asab.Config.getint(config_section_name, "proxy_connect_timeout", fallback=10)
+
+		if self.ProxyHost and not self.ProxyPort:
+			raise ValueError("SMTP proxy is configured but `proxy_port` is empty")
+		if self.ProxyPort and not self.ProxyHost:
+			raise ValueError("SMTP proxy is configured but `proxy_host` is empty")
 
 		if len(self.User) == 0:
 			self.User = None
@@ -69,8 +91,8 @@ class EmailOutputService(asab.Service, OutputABC):
 		self, *,
 		email_to,
 		body,
-		email_cc=[],
-		email_bcc=[],
+		email_cc=None,
+		email_bcc=None,
 		email_subject=None,
 		email_from=None,
 		attachments=None,
@@ -130,25 +152,44 @@ class EmailOutputService(asab.Service, OutputABC):
 				error_dict={"tenant": effective_tenant or "unspecified"}
 			)
 
+		# Parse/normalize resolved recipients once and use for both header and envelope.
+		to_recipients = []
+		for email_address in to_list:
+			_, sender_email = self.format_sender_info(str(email_address))
+			if sender_email:
+				to_recipients.append(sender_email)
+
+		if not to_recipients:
+			raise ASABIrisError(
+				ErrorCode.INVALID_SERVICE_CONFIGURATION,
+				tech_message="No valid recipient emails after normalization.",
+				error_i18n_key="No recipients configured for '{{tenant}}'.",
+				error_dict={"tenant": effective_tenant or "unspecified"}
+			)
+
 		# Prepare Message
 		msg = email.message.EmailMessage()
 		msg.set_content(body, subtype='html')
-
-		if email_to is not None:
-			assert isinstance(email_to, list)
-			formatted_email_to = []
-			for email_address in email_to:
-				formatted_sender, sender_email = self.format_sender_info(email_address)
-				formatted_email_to.append(sender_email)
-			msg['To'] = ', '.join(formatted_email_to)
+		msg['To'] = ', '.join(to_recipients)
+		cc_recipients = []
+		bcc_recipients = []
 
 		if email_cc is not None:
 			assert isinstance(email_cc, list)
 			formatted_email_cc = []
 			for email_address in email_cc:
-				formatted_sender, sender_email = self.format_sender_info(email_address)
-				formatted_email_cc.append(sender_email)
+				_, sender_email = self.format_sender_info(str(email_address))
+				if sender_email:
+					formatted_email_cc.append(sender_email)
+					cc_recipients.append(sender_email)
 			msg['Cc'] = ', '.join(formatted_email_cc)
+
+		if email_bcc is not None:
+			assert isinstance(email_bcc, list)
+			for email_address in email_bcc:
+				_, sender_email = self.format_sender_info(str(email_address))
+				if sender_email:
+					bcc_recipients.append(sender_email)
 
 		if email_subject is not None and len(email_subject) > 0:
 			msg['Subject'] = email_subject
@@ -178,23 +219,49 @@ class EmailOutputService(asab.Service, OutputABC):
 		delay = 5  # seconds
 
 		for attempt in range(retry_attempts):
+			proxy_socket = None
 			try:
-				result = await aiosmtplib.send(
-					msg,
-					sender=sender,
-					recipients=to_list + (email_cc or []) + (email_bcc or []),
-					hostname=self.Host,
-					port=int(self.Port) if self.Port != "" else None,
-					username=self.User,
-					password=self.Password,
-					use_tls=self.SSL,
-					start_tls=self.StartTLS,
-					cert_bundle=self.Cert or None,
-					validate_certs=self.ValidateCerts
-				)
+				send_kwargs = {
+					"sender": sender,
+					"recipients": to_recipients + cc_recipients + bcc_recipients,
+					"username": self.User,
+					"password": self.Password,
+					"use_tls": self.SSL,
+					"start_tls": self.StartTLS,
+					"cert_bundle": self.Cert or None,
+					"validate_certs": self.ValidateCerts,
+				}
+
+				if self.ProxyHost:
+					proxy_socket = await self._connect_via_http_proxy()
+					send_kwargs["sock"] = proxy_socket
+					send_kwargs["hostname"] = None
+					send_kwargs["port"] = None
+				else:
+					send_kwargs["hostname"] = self.Host
+					send_kwargs["port"] = int(self.Port) if self.Port != "" else None
+
+				result = await aiosmtplib.send(msg, **send_kwargs)
 				L.log(asab.LOG_NOTICE, "Email sent", struct_data={'result': result[1], "host": self.Host})
 				break  # Email sent successfully, exit the retry loop
 
+			except ProxyConnectError as e:
+				L.warning(
+					"Proxy connection failed: {}".format(e),
+					struct_data={"proxy_host": self.ProxyHost, "proxy_port": self.ProxyPort, "host": self.Host}
+				)
+				if attempt < retry_attempts - 1:
+					L.info("Retrying email send after proxy connection failure, attempt {}".format(attempt + 1))
+					await asyncio.sleep(delay)
+					continue
+				raise ASABIrisError(
+					ErrorCode.SMTP_CONNECTION_ERROR,
+					tech_message="SMTP proxy connection failed: {}.".format(str(e)),
+					error_i18n_key="Could not connect to SMTP for host '{{host}}'.",
+					error_dict={
+						"host": self.Host,
+					}
+				)
 			except aiosmtplib.errors.SMTPConnectError as e:
 				L.warning("Connection failed: {}".format(e), struct_data={"host": self.Host, "port": self.Port})
 				if attempt < retry_attempts - 1:
@@ -277,6 +344,92 @@ class EmailOutputService(asab.Service, OutputABC):
 						"host": self.Host
 					}
 				)
+			finally:
+				if proxy_socket is not None:
+					try:
+						proxy_socket.close()
+					except OSError:
+						pass
+
+	def _effective_smtp_port(self):
+		if self.Port != "":
+			return int(self.Port)
+		if self.SSL:
+			return 465
+		if self.StartTLS:
+			return 587
+		return 25
+
+	def _proxy_connect_headers(self, target_host, target_port):
+		headers = [
+			"CONNECT {}:{} HTTP/1.1".format(target_host, target_port),
+			"Host: {}:{}".format(target_host, target_port),
+		]
+		if self.ProxyUser:
+			auth_string = "{}:{}".format(self.ProxyUser, self.ProxyPassword)
+			encoded = base64.b64encode(auth_string.encode("utf-8")).decode("ascii")
+			headers.append("Proxy-Authorization: Basic {}".format(encoded))
+		return "\r\n".join(headers) + "\r\n\r\n"
+
+	async def _read_http_headers(self, sock_obj):
+		loop = asyncio.get_running_loop()
+		buffer = b""
+		max_headers_size = 65536
+		while b"\r\n\r\n" not in buffer:
+			chunk = await loop.sock_recv(sock_obj, 4096)
+			if not chunk:
+				raise ProxyConnectError("Proxy closed connection before CONNECT response")
+			buffer += chunk
+			if len(buffer) > max_headers_size:
+				raise ProxyConnectError("Proxy CONNECT response headers are too large")
+		return buffer.split(b"\r\n\r\n", 1)[0]
+
+	async def _connect_via_http_proxy(self):
+		target_host = self.Host
+		target_port = self._effective_smtp_port()
+
+		try:
+			proxy_port = int(self.ProxyPort)
+		except ValueError as e:
+			raise ProxyConnectError("Invalid proxy_port '{}': {}".format(self.ProxyPort, str(e)))
+
+		sock_obj = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		sock_obj.setblocking(False)
+		loop = asyncio.get_running_loop()
+
+		try:
+			await asyncio.wait_for(
+				loop.sock_connect(sock_obj, (self.ProxyHost, proxy_port)),
+				timeout=self.ProxyConnectTimeout
+			)
+			request = self._proxy_connect_headers(target_host, target_port).encode("ascii")
+			await asyncio.wait_for(
+				loop.sock_sendall(sock_obj, request),
+				timeout=self.ProxyConnectTimeout
+			)
+			header_bytes = await asyncio.wait_for(
+				self._read_http_headers(sock_obj),
+				timeout=self.ProxyConnectTimeout
+			)
+		except asyncio.TimeoutError:
+			sock_obj.close()
+			raise ProxyConnectError("Timeout while connecting to proxy {}:{}".format(self.ProxyHost, proxy_port))
+		except Exception as e:
+			sock_obj.close()
+			raise ProxyConnectError(str(e))
+
+		try:
+			status_line = header_bytes.split(b"\r\n", 1)[0].decode("iso-8859-1")
+			status_code = int(status_line.split(" ", 2)[1])
+		except Exception as e:
+			sock_obj.close()
+			raise ProxyConnectError("Malformed proxy CONNECT response: {}".format(str(e)))
+
+		if status_code != 200:
+			sock_obj.close()
+			raise ProxyConnectError("Proxy CONNECT failed with status {}".format(status_code))
+
+		return sock_obj
 
 	def format_sender_info(self, email_info):
 		"""

--- a/etc/asab-iris.conf
+++ b/etc/asab-iris.conf
@@ -17,6 +17,16 @@ cert_bundle=           # Path to CA bundle (PEM) used when validate_certs=true.
                        # Leave empty to use system trust store.
                        # Ignored if validate_certs=false.
 
+# Optional HTTP CONNECT proxy for SMTP transport.
+# Leave proxy_host/proxy_port empty to connect directly.
+proxy_host=
+proxy_port=
+proxy_user=            # Optional: sends Proxy-Authorization: Basic ...
+proxy_password=
+proxy_connect_timeout=10
+                       # Applies only to the proxy TCP/CONNECT handshake.
+                       # SMTP EHLO/TLS/AUTH/DATA keep the normal SMTP client timeout.
+
 
 [slack]
 # Configure the integration with Slack


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP CONNECT proxy support for SMTP with configurable host, port, optional auth, and timeout.
  * Unified recipient normalization and deduplication; send now uses explicit keyword-only parameters and email_cc/email_bcc default to None.

* **Bug Fixes**
  * Improved retry and error handling for proxy and SMTP failures; ensures proxy connections are cleaned up on error.

* **Documentation**
  * README updated to document proxy configuration and enabling conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->