### PR TITLE
Do not require tenant at get_features endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Push notification supports tenant configuration. (#121 v26.02-alpha)
 - Delegated Email MS365 support. (#119 v26.04-alpha)
 - Introduce tenant service. (#120 v26.04-alpha2)
+- Do not require tenant at get_features endpoint (#131 v26.16-alpha1)
 
 ## v25.47
 

--- a/asabiris/handlers/webhandler.py
+++ b/asabiris/handlers/webhandler.py
@@ -46,6 +46,7 @@ class WebHandler(object):
 		web_app.router.add_get(r"/authorize_ms365", self.authorize_ms365)
 
 
+	@asab.web.tenant.allow_no_tenant
 	async def get_features(self, request):
 		"""
 		Return the application's features (enabled orchestrators).


### PR DESCRIPTION
# Issue
Since #120 `GET /features` requires the `tenant` parameter in query although it is not necessary.

# Solution
Add `@asab.web.tenant.allow_no_tenant` to `get_features` handler.