### PR TITLE
Add tzdata dependency required by xhtml2pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## v25.xx
 
+### Fixes
+- Add tzdata dependency required by xhtml2pdf (#133 v26.16-alpha2)
+
 ### Features
 - New output push notifications. (#117 v25.50-alpha)
 - Push notification supports tenant configuration. (#121 v26.02-alpha)

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apk add --no-cache \
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir pygit2==1.11 aiokafka aiosmtplib msal fastjsonschema jsonata-python
-RUN pip3 install --no-cache-dir jinja2 markdown pyyaml xhtml2pdf git+https://github.com/TeskaLabs/asab.git
-RUN pip3 install --no-cache-dir sentry-sdk slack_sdk pytz
+RUN pip3 install --no-cache-dir jinja2 markdown pyyaml xhtml2pdf pytz tzdata git+https://github.com/TeskaLabs/asab.git
+RUN pip3 install --no-cache-dir sentry-sdk slack_sdk
 
 RUN mkdir -p /app/asab-iris
 


### PR DESCRIPTION
- the app fails to start entirely:
```
Traceback (most recent call last):
  File "/usr/lib/python3.11/zoneinfo/_common.py", line 12, in load_tzdata
    return resources.files(package_name).joinpath(resource_name).open("rb")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/resources/_common.py", line 22, in files
    return from_package(get_package(package))
                        ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/resources/_common.py", line 53, in get_package
    resolved = resolve(package)
               ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/resources/_common.py", line 44, in resolve
    return cand if isinstance(cand, types.ModuleType) else importlib.import_module(cand)
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'tzdata'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/asab-iris/asab-iris.py", line 2, in <module>
    import asabiris
  File "/app/asab-iris/asabiris/__init__.py", line 1, in <module>
    from .app import ASABIRISApplication
  File "/app/asab-iris/asabiris/app.py", line 12, in <module>
    from .formatter.jinja import JinjaFormatterService
  File "/app/asab-iris/asabiris/formatter/__init__.py", line 3, in <module>
    from .pdf.service import PdfFormatterService
  File "/app/asab-iris/asabiris/formatter/pdf/__init__.py", line 1, in <module>
    from .service import PdfFormatterService
  File "/app/asab-iris/asabiris/formatter/pdf/service.py", line 4, in <module>
    import xhtml2pdf.pisa
  File "/usr/lib/python3.11/site-packages/xhtml2pdf/pisa.py", line 26, in <module>
    from xhtml2pdf.document import pisaDocument
  File "/usr/lib/python3.11/site-packages/xhtml2pdf/document.py", line 23, in <module>
    from xhtml2pdf.builders.signs import PDFSignature
  File "/usr/lib/python3.11/site-packages/xhtml2pdf/builders/signs.py", line 6, in <module>
    from pyhanko.sign import signers, timestamps
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/__init__.py", line 1, in <module>
    from .signers import (
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/signers/__init__.py", line 15, in <module>
    from .functions import async_sign_pdf, embed_payload_with_cms, sign_pdf
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/signers/functions.py", line 17, in <module>
    from .pdf_signer import PdfSignatureMetadata, PdfSigner
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/signers/pdf_signer.py", line 48, in <module>
    from pyhanko.sign.validation.ades import ades_timestamp_validation_internal
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/validation/ades.py", line 121, in <module>
    from .qualified.assess import (
  File "/usr/lib/python3.11/site-packages/pyhanko/sign/validation/qualified/assess.py", line 41, in <module>
    2016, 7, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo('Europe/Brussels')
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/zoneinfo/_common.py", line 24, in load_tzdata
    raise ZoneInfoNotFoundError(f"No time zone found with key {key}")
zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key Europe/Brussels'
```
- `tzdata` is included in most linux distros, but not in alpine
- some dependency started using `zoneinfo` in their latest update, which expects `tzdata`