### PR TITLE
Patch v26.12: Critical: Add tzdata dependency required by xhtml2pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 # Patch
+- Critical: Add tzdata dependency required by xhtml2pdf (#134 v26.12-beta4)
 - Do not require tenant at get_features endpoint (#132 v26.12-beta3)
 
 ## v25.xx

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apk add --no-cache \
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir pygit2==1.11 aiokafka aiosmtplib msal fastjsonschema jsonata-python
-RUN pip3 install --no-cache-dir jinja2 markdown pyyaml xhtml2pdf git+https://github.com/TeskaLabs/asab.git@v26.12.02
-RUN pip3 install --no-cache-dir sentry-sdk slack_sdk pytz
+RUN pip3 install --no-cache-dir jinja2 markdown pyyaml xhtml2pdf pytz tzdata git+https://github.com/TeskaLabs/asab.git@v26.12.02
+RUN pip3 install --no-cache-dir sentry-sdk slack_sdk
 
 RUN mkdir -p /app/asab-iris
 


### PR DESCRIPTION
see #133 

this enables the app to start at all