### PR TITLE
Patch v26.12 - Use forked kazoo for persistent watcher support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@
       - pip install requests
       - pip install aiohttp
       - pip install -U git+https://github.com/TeskaLabs/asab
+      - pip install -U git+https://github.com/TeskaLabs/kazoo
       - pip install msal
       - pip install temp
       - pip install aiokafka
@@ -51,6 +52,7 @@
       - pip install requests
       - pip install aiohttp
       - pip install -U git+https://github.com/TeskaLabs/asab
+      - pip install -U git+https://github.com/TeskaLabs/kazoo
       - pip install msal
       - pip install temp
       - pip install aiokafka
@@ -79,6 +81,7 @@
       - pip install requests
       - pip install aiohttp
       - pip install -U git+https://github.com/TeskaLabs/asab
+      - pip install -U git+https://github.com/TeskaLabs/kazoo
       - pip install msal
       - pip install temp
       - pip install aiokafka
@@ -110,6 +113,7 @@
       - pip install pytz
       - pip install jsonata-python
       - pip install -U git+https://github.com/TeskaLabs/asab
+      - pip install -U git+https://github.com/TeskaLabs/kazoo
       - pip install msal
       - python3 -m flake8 asabiris
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,24 @@ RUN apk add --no-cache \
      cairo-dev
 
 RUN pip3 install --upgrade pip
-RUN pip3 install --no-cache-dir pygit2==1.11 aiokafka aiosmtplib msal fastjsonschema jsonata-python
-RUN pip3 install --no-cache-dir jinja2 markdown pyyaml xhtml2pdf pytz tzdata git+https://github.com/TeskaLabs/asab.git@v26.12.02
-RUN pip3 install --no-cache-dir sentry-sdk slack_sdk
+RUN pip3 install --no-cache-dir \
+    pygit2==1.11 \
+    aiokafka \
+    aiosmtplib \
+    msal \
+    fastjsonschema \
+    jsonata-python \
+    jinja2 \
+    markdown \
+    pyyaml \
+    xhtml2pdf \
+    pytz \
+    tzdata \
+    sentry-sdk \
+    slack_sdk \
+    git+https://github.com/TeskaLabs/kazoo.git \
+    git+https://github.com/TeskaLabs/asab.git@v26.12.03
+# ^ Use vendored Kazoo library till https://github.com/python-zk/kazoo/pull/715 is merged (persistent watcher support)
 
 RUN mkdir -p /app/asab-iris
 


### PR DESCRIPTION
(cherry picked from commit 9e5184d925034f4b66bca6d20edb54069e6b181d)