### PR TITLE
Accept Teams Workflows 202 responses as successful sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 
 
+## v26.xx
+- Accept Microsoft Teams Workflows 202 Accepted responses as successful sends.
 
-## v25.xx
+## v25.12
 
 ### Fixes
 - Use vendored kazoo for persistent watcher support (#135 v26.16-alpha3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,21 @@
 ## v26.xx
 - Accept Microsoft Teams Workflows 202 Accepted responses as successful sends.
 
-## v25.12
-
-### Fixes
-- Use vendored kazoo for persistent watcher support (#135 v26.16-alpha3)
-- Add tzdata dependency required by xhtml2pdf (#133 v26.16-alpha2)
+## v26.12
 
 ### Features
 - New output push notifications. (#117 v25.50-alpha)
 - Push notification supports tenant configuration. (#121 v26.02-alpha)
 - Delegated Email MS365 support. (#119 v26.04-alpha)
 - Introduce tenant service. (#120 v26.04-alpha2)
-- Do not require tenant at get_features endpoint (#131 v26.16-alpha1)
+
+# Fixes
+- Allow no tenant to push notification. (#129 v26.12-beta)
+- Update asab: v26.12.02 into dockerfile (#130 v26.12-beta2)
+- Do not require tenant at get_features endpoint (#131 v26.12-beta3)
+- Critical: Add tzdata dependency required by xhtml2pdf (#134 v26.12-beta4)
+- Use forked kazoo for persistent watcher support (#135 v26.12-beta5)
+- Accept Microsoft Teams Workflows 202 Accepted responses as successfully sends (#136 v26.12-beta6)
 
 ## v25.47
 

--- a/asabiris/output/msteams/service.py
+++ b/asabiris/output/msteams/service.py
@@ -90,7 +90,7 @@ class MSTeamsOutputService(asab.Service, OutputABC):
         # Sending the message to MS Teams using aiohttp
         async with aiohttp.ClientSession() as session:
             async with session.post(webhook_url, json=adaptive_card) as resp:
-                if resp.status == 200:
+                if resp.status in (200, 202):
                     L.log(asab.LOG_NOTICE, "MS Teams message sent successfully.")
                     return True
                 else:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Microsoft Teams integration now correctly treats 202 Accepted responses as successful sends.

* **Chores**
  * Dropped support for Python 3.7 and 3.8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TeskaLabs/asab-iris/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->