### PR TITLE
Add AUDIT logging for notification recipients

### DIFF
--- a/asabiris/__init__.py
+++ b/asabiris/__init__.py
@@ -1,5 +1,7 @@
 from .app import ASABIRISApplication
+from .audit import AuditLogger
 
 __all__ = [
-	"ASABIRISApplication"
+	"ASABIRISApplication",
+	"AuditLogger",
 ]

--- a/asabiris/audit.py
+++ b/asabiris/audit.py
@@ -1,0 +1,4 @@
+import logging
+
+
+AuditLogger = logging.getLogger("AUDIT")

--- a/asabiris/output/mattermost/service.py
+++ b/asabiris/output/mattermost/service.py
@@ -7,6 +7,7 @@ import asab
 
 from ...errors import ASABIrisError, ErrorCode
 from ...output_abc import OutputABC
+from ...audit import AuditLogger
 
 L = logging.getLogger(__name__)
 
@@ -177,7 +178,13 @@ class MattermostOutputService(asab.Service, OutputABC):
 			}
 		)
 
-		return await self._post_json(config, "/api/v4/posts", post_payload)
+		result = await self._post_json(config, "/api/v4/posts", post_payload)
+		AuditLogger.log(
+			asab.LOG_NOTICE,
+			"Mattermost message sent",
+			struct_data={"channel_id": channel_id, "username": username, "tenant": effective_tenant},
+		)
+		return result
 
 	async def get_user_ids(self, config, bot_username, target_username):
 		"""

--- a/asabiris/output/ms365/service.py
+++ b/asabiris/output/ms365/service.py
@@ -10,6 +10,7 @@ import requests
 import msal
 
 from ...errors import ASABIrisError, ErrorCode
+from ...audit import AuditLogger
 from ...output_abc import OutputABC
 
 L = logging.getLogger(__name__)
@@ -828,6 +829,11 @@ class M365EmailOutputService(asab.Service, OutputABC):
 				) from e
 		# Success cases
 		if resp.status_code in (200, 202, 204):
+			AuditLogger.log(
+				asab.LOG_NOTICE,
+				"Email sent",
+				struct_data={"provider": "m365", "to": to_list, "cc": cc_list, "bcc": bcc_list, "tenant": effective_tenant},
+			)
 			return True
 
 		# 400 Bad request

--- a/asabiris/output/msteams/service.py
+++ b/asabiris/output/msteams/service.py
@@ -1,9 +1,13 @@
 import logging
 import configparser
+import urllib.parse
+
 import aiohttp
 import asab
+
 from ...errors import ASABIrisError, ErrorCode
 from ...output_abc import OutputABC
+from ...audit import AuditLogger
 
 L = logging.getLogger(__name__)
 
@@ -106,6 +110,14 @@ class MSTeamsOutputService(asab.Service, OutputABC):
         async with aiohttp.ClientSession() as session:
             async with session.post(webhook_url, json=adaptive_card) as resp:
                 if resp.status in (200, 202):
+                    AuditLogger.log(
+                        asab.LOG_NOTICE,
+                        "Microsoft Teams message sent",
+                        struct_data={
+                            "webhook_host": urllib.parse.urlsplit(webhook_url).hostname,
+                            "tenant": effective_tenant,
+                        },
+                    )
                     L.log(
                         asab.LOG_NOTICE,
                         "Microsoft Teams message sent successfully.",

--- a/asabiris/output/pushnotification/service.py
+++ b/asabiris/output/pushnotification/service.py
@@ -4,6 +4,7 @@ import asab
 import aiohttp
 
 from ...errors import ASABIrisError, ErrorCode
+from ...audit import AuditLogger
 
 L = logging.getLogger(__name__)
 SLACK_LINK_RE = re.compile(r"<(https?://[^>|]+)(?:\|[^>]+)?>")
@@ -148,4 +149,9 @@ class PushOutputService(asab.Service):
 				error_dict={"error_message": str(err)}
 			)
 
+		AuditLogger.log(
+			asab.LOG_NOTICE,
+			"Push notification sent",
+			struct_data={"topic": topic, "tenant": tenant},
+		)
 		return True

--- a/asabiris/output/slack/service.py
+++ b/asabiris/output/slack/service.py
@@ -12,6 +12,7 @@ except ModuleNotFoundError:
 
 from ...errors import ASABIrisError, ErrorCode
 from ...output_abc import OutputABC
+from ...audit import AuditLogger
 
 if slack_sdk is not None:
 	SlackApiError = slack_sdk.errors.SlackApiError
@@ -130,7 +131,6 @@ class SlackOutputService(asab.Service, OutputABC):
 				"blocks": blocks,
 			}
 		)
-
 		try:
 			client.chat_postMessage(
 				channel=channel_id,
@@ -154,6 +154,7 @@ class SlackOutputService(asab.Service, OutputABC):
 			"Slack message sent successfully.",
 			struct_data={"channel": channel}
 		)
+		AuditLogger.log(asab.LOG_NOTICE, "Slack message sent", struct_data={"channel": channel, "channel_id": channel_id})
 
 
 	async def send_files(self, body: str, atts_gen, channel=None):
@@ -210,6 +211,7 @@ class SlackOutputService(asab.Service, OutputABC):
 			"Slack files sent successfully.",
 			struct_data={"channel": channel}
 		)
+		AuditLogger.log(asab.LOG_NOTICE, "Slack files sent", struct_data={"channel": channel, "channel_id": channel_id})
 
 
 	def get_channel_id(self, client, channel_name, types=None):

--- a/asabiris/output/slack/service.py
+++ b/asabiris/output/slack/service.py
@@ -211,7 +211,7 @@ class SlackOutputService(asab.Service, OutputABC):
 			"Slack files sent successfully.",
 			struct_data={"channel": channel}
 		)
-		AuditLogger.log(asab.LOG_NOTICE, "Slack files sent", struct_data={"channel": channel, "channel_id": channel_id})
+		AuditLogger.log(asab.LOG_NOTICE, "Slack files sent", struct_data={"channel_id": channel_id})
 
 
 	def get_channel_id(self, client, channel_name, types=None):

--- a/asabiris/output/sms/service.py
+++ b/asabiris/output/sms/service.py
@@ -12,6 +12,7 @@ import pytz
 
 from ...output_abc import OutputABC
 from ...errors import ASABIrisError, ErrorCode
+from ...audit import AuditLogger
 
 L = logging.getLogger(__name__)
 
@@ -411,5 +412,9 @@ class SMSOutputService(asab.Service, OutputABC):
 						"SMS part sent successfully.",
 						struct_data={"tenant": effective_tenant, "api_url": api_url},
 					)
-
+		AuditLogger.log(
+			asab.LOG_NOTICE,
+			"SMS sent",
+			struct_data={"phone": phone, "tenant": effective_tenant},
+		)
 		return True

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -13,6 +13,7 @@ import aiosmtplib.protocol as smtp_protocol
 
 from ...output_abc import OutputABC
 from ...errors import ASABIrisError, ErrorCode
+from ...audit import AuditLogger
 
 #
 
@@ -362,6 +363,17 @@ class EmailOutputService(asab.Service, OutputABC):
 						"port": self.Port,
 						"tenant": effective_tenant,
 						"recipient_count": len(to_recipients),
+					},
+				)
+				AuditLogger.log(
+					asab.LOG_NOTICE,
+					"Email sent",
+					struct_data={
+						"provider": "smtp",
+						"to": to_recipients,
+						"cc": cc_recipients,
+						"bcc": bcc_recipients,
+						"tenant": effective_tenant,
 					},
 				)
 				break  # Email sent successfully, exit the retry loop

--- a/asabiris/output/smtp/service.py
+++ b/asabiris/output/smtp/service.py
@@ -354,28 +354,6 @@ class EmailOutputService(asab.Service, OutputABC):
 						cert_bundle=self.Cert or None,
 						validate_certs=self.ValidateCerts
 					)
-				L.log(
-					asab.LOG_NOTICE,
-					"Email sent successfully via SMTP.",
-					struct_data={
-						"result": result[1],
-						"host": self.Host,
-						"port": self.Port,
-						"tenant": effective_tenant,
-						"recipient_count": len(to_recipients),
-					},
-				)
-				AuditLogger.log(
-					asab.LOG_NOTICE,
-					"Email sent",
-					struct_data={
-						"provider": "smtp",
-						"to": to_recipients,
-						"cc": cc_recipients,
-						"bcc": bcc_recipients,
-						"tenant": effective_tenant,
-					},
-				)
 				break  # Email sent successfully, exit the retry loop
 
 			except ProxyConnectError as e:
@@ -601,6 +579,29 @@ class EmailOutputService(asab.Service, OutputABC):
 						"host": self.Host
 					}
 				)
+
+		L.log(
+			asab.LOG_NOTICE,
+			"Email sent successfully via SMTP.",
+			struct_data={
+				"result": result[1],
+				"host": self.Host,
+				"port": self.Port,
+				"tenant": effective_tenant,
+				"recipient_count": len(to_recipients),
+			},
+		)
+		AuditLogger.log(
+			asab.LOG_NOTICE,
+			"Email sent",
+			struct_data={
+				"provider": "smtp",
+				"to": to_recipients,
+				"cc": cc_recipients,
+				"bcc": bcc_recipients,
+				"tenant": effective_tenant,
+			},
+		)
 
 	async def _send_via_proxy_smtp_client(self, *, msg, sender, recipients):
 		"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized audit logging for successfully delivered notifications and messages across Mattermost, Microsoft 365, Microsoft Teams, push notifications, Slack, SMS, and SMTP.
  * Audit records include relevant delivery details, such as destination, provider, channel, recipient, and tenant information.
  * Made the audit logging capability available through the public package interface.
  * Existing delivery behavior, responses, and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->